### PR TITLE
Wagtail 5.1: Shared include field_as_li.html will be removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Support for Wagtail version 5.1
+
 ## 0.3.0
 
 ### Added

--- a/wagtail_purge/templates/index.html
+++ b/wagtail_purge/templates/index.html
@@ -24,7 +24,9 @@
         {% csrf_token %}
         <ul class="fields">
             {% for field in form %}
-            {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+            <li>
+                {% include "wagtailadmin/shared/field.html" with field=field %}
+            </li>
             {% endfor %}
             <li><input type="submit" value="{% trans 'Submit Purge Request' %}" class="button" /></li>
         </ul>


### PR DESCRIPTION
[Wagtail 5.1 release notes](https://docs.wagtail.org/en/stable/releases/5.1.html)

Changes:
- [Shared include field_as_li.html will be removed](https://docs.wagtail.org/en/stable/releases/5.1.html#shared-include-field-as-li-html-will-be-removed)

Upstream PR: https://github.com/torchbox/wagtail-purge/pull/7